### PR TITLE
4764 connect hn web to backend (r50) http external endpoint

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,6 +4,9 @@ target/
 !**/src/main/**/target/
 !**/src/test/**/target/
 
+### Cert Files ###
+**/keystore/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,6 +6,7 @@ target/
 
 ### Cert Files ###
 **/keystore/
+**/application-*.yaml
 
 ### STS ###
 .apt_generated

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -59,12 +59,6 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
  		
-		<!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
-		<dependency>
-		    <groupId>org.apache.httpcomponents</groupId>
-		    <artifactId>httpclient</artifactId>
-		</dependency>		
-
  		<!-- HL7 -->
 		<dependency>
 			<groupId>ca.uhn.hapi</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -41,6 +41,11 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+		    <groupId>org.springframework.boot</groupId>
+		    <artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+
  		<!-- OpenAPI/Swagger -->
         <dependency>
             <groupId>org.springdoc</groupId>
@@ -54,6 +59,12 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
  		
+		<!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+		<dependency>
+		    <groupId>org.apache.httpcomponents</groupId>
+		    <artifactId>httpclient</artifactId>
+		</dependency>		
+
  		<!-- HL7 -->
 		<dependency>
 			<groupId>ca.uhn.hapi</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -82,7 +82,19 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+		
+		<dependency>
+		    <groupId>com.squareup.okhttp3</groupId>
+		    <artifactId>okhttp</artifactId>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>com.squareup.okhttp3</groupId>
+		    <artifactId>mockwebserver</artifactId>
+		    <scope>test</scope>
+		</dependency>
+		
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/config/HnWebConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/config/HnWebConfig.java
@@ -1,7 +1,31 @@
 package ca.bc.gov.hlth.hnweb.config;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
 
 import ca.uhn.hl7v2.DefaultHapiContext;
 import ca.uhn.hl7v2.HapiContext;
@@ -14,6 +38,22 @@ import ca.uhn.hl7v2.parser.Parser;
 @Configuration
 public class HnWebConfig {
 
+	private static final Logger logger = org.slf4j.LoggerFactory.getLogger(HnWebConfig.class);
+
+	private static final String KEY_STORE_TYPE_PKCS12 = "pkcs12";
+
+	@Value("${R50.user.name}")
+	private String userName;
+
+	@Value("${R50.user.password}")
+	private String userPassword;
+
+	@Value("classpath:${R50.cert.file}")
+	private Resource certFile;
+
+	@Value("${R50.cert.password}")
+	private String certPassword;
+
 	@Bean
 	public HapiContext hapiContext() {
 		return new DefaultHapiContext();
@@ -23,4 +63,48 @@ public class HnWebConfig {
 	public Parser parser() {
 		return hapiContext().getGenericParser();
 	}
+
+	/**
+	 * Creates a {@link RestTemplate} configured to access the Enroll Subscriber endpoint
+	 * @return
+	 */
+	@Bean
+	public RestTemplate enrollmentRestTemplate() {
+
+		SSLConnectionSocketFactory sslConnectionSocketFactory = null;
+		try {
+			KeyStore keyStore = KeyStore.getInstance(KEY_STORE_TYPE_PKCS12);
+			keyStore.load(new FileInputStream(certFile.getFile()), certPassword.toCharArray());
+	
+			SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
+		    sslContextBuilder.setProtocol("TLS");
+		    sslContextBuilder.loadKeyMaterial(keyStore, certPassword.toCharArray());
+		    sslContextBuilder.loadTrustMaterial(new TrustSelfSignedStrategy());
+	
+		    sslConnectionSocketFactory = new SSLConnectionSocketFactory(sslContextBuilder.build(), NoopHostnameVerifier.INSTANCE);
+		} catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException | UnrecoverableKeyException | KeyManagementException e) {
+			logger.error("Error creating SSL Rest Template {}", e.getMessage());
+		}
+		
+		CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+		 
+	    credentialsProvider.setCredentials(AuthScope.ANY, 
+	                    new UsernamePasswordCredentials(userName, userPassword));
+	 	 
+	    CloseableHttpClient httpClient = HttpClients.custom()
+	            .setSSLSocketFactory(sslConnectionSocketFactory)
+	            .setDefaultCredentialsProvider(credentialsProvider)
+	            //TODO (daveb-hni) Check if values need to be set for these parameters
+//	            .setMaxConnTotal(Integer.valueOf(5))
+//	            .setMaxConnPerRoute(Integer.valueOf(5))
+	            .build();
+	    
+	    HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+	    requestFactory.setConnectTimeout(60000); // 10 seconds
+	    requestFactory.setReadTimeout(60000); // 10 seconds
+	    
+	    return new RestTemplate(requestFactory);		
+	}
+
 }
+

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/config/HnWebConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/config/HnWebConfig.java
@@ -25,4 +25,3 @@ public class HnWebConfig {
 	}
 
 }
-

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/config/HnWebConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/config/HnWebConfig.java
@@ -1,31 +1,7 @@
 package ca.bc.gov.hlth.hnweb.config;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
-
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.ssl.SSLContextBuilder;
-import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.web.client.RestTemplate;
 
 import ca.uhn.hl7v2.DefaultHapiContext;
 import ca.uhn.hl7v2.HapiContext;
@@ -38,22 +14,6 @@ import ca.uhn.hl7v2.parser.Parser;
 @Configuration
 public class HnWebConfig {
 
-	private static final Logger logger = org.slf4j.LoggerFactory.getLogger(HnWebConfig.class);
-
-	private static final String KEY_STORE_TYPE_PKCS12 = "pkcs12";
-
-	@Value("${R50.user.name}")
-	private String userName;
-
-	@Value("${R50.user.password}")
-	private String userPassword;
-
-	@Value("classpath:${R50.cert.file}")
-	private Resource certFile;
-
-	@Value("${R50.cert.password}")
-	private String certPassword;
-
 	@Bean
 	public HapiContext hapiContext() {
 		return new DefaultHapiContext();
@@ -62,48 +22,6 @@ public class HnWebConfig {
 	@Bean
 	public Parser parser() {
 		return hapiContext().getGenericParser();
-	}
-
-	/**
-	 * Creates a {@link RestTemplate} configured to access the Enroll Subscriber endpoint
-	 * @return
-	 */
-	@Bean
-	public RestTemplate enrollmentRestTemplate() {
-
-		SSLConnectionSocketFactory sslConnectionSocketFactory = null;
-		try {
-			KeyStore keyStore = KeyStore.getInstance(KEY_STORE_TYPE_PKCS12);
-			keyStore.load(new FileInputStream(certFile.getFile()), certPassword.toCharArray());
-	
-			SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
-		    sslContextBuilder.setProtocol("TLS");
-		    sslContextBuilder.loadKeyMaterial(keyStore, certPassword.toCharArray());
-		    sslContextBuilder.loadTrustMaterial(new TrustSelfSignedStrategy());
-	
-		    sslConnectionSocketFactory = new SSLConnectionSocketFactory(sslContextBuilder.build(), NoopHostnameVerifier.INSTANCE);
-		} catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException | UnrecoverableKeyException | KeyManagementException e) {
-			logger.error("Error creating SSL Rest Template {}", e.getMessage());
-		}
-		
-		CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-		 
-	    credentialsProvider.setCredentials(AuthScope.ANY, 
-	                    new UsernamePasswordCredentials(userName, userPassword));
-	 	 
-	    CloseableHttpClient httpClient = HttpClients.custom()
-	            .setSSLSocketFactory(sslConnectionSocketFactory)
-	            .setDefaultCredentialsProvider(credentialsProvider)
-	            //TODO (daveb-hni) Check if values need to be set for these parameters
-//	            .setMaxConnTotal(Integer.valueOf(5))
-//	            .setMaxConnPerRoute(Integer.valueOf(5))
-	            .build();
-	    
-	    HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
-	    requestFactory.setConnectTimeout(60000); // 10 seconds
-	    requestFactory.setReadTimeout(60000); // 10 seconds
-	    
-	    return new RestTemplate(requestFactory);		
 	}
 
 }

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/config/WebClientConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/config/WebClientConfig.java
@@ -1,0 +1,96 @@
+package ca.bc.gov.hlth.hnweb.config;
+
+import java.io.FileInputStream;
+import java.security.KeyStore;
+
+import javax.net.ssl.KeyManagerFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+@Configuration
+public class WebClientConfig {
+
+	private final Logger logger = LoggerFactory.getLogger("WebClientConfig");
+
+	private static final String KEY_STORE_TYPE_PKCS12 = "pkcs12";
+
+	private static final String KEY_MANAGER_FACTORY_TYPE_SUN_X509 = "SunX509";
+
+	@Value("${R50.url}")
+	private String r50Url;
+	 
+	@Value("${R50.user.name}")
+	private String userName;
+
+	@Value("${R50.user.password}")
+	private String userPassword;
+
+	@Value("classpath:${R50.cert.file}")
+	private Resource certFile;
+
+	@Value("${R50.cert.password}")
+	private String certPassword;
+
+	@Bean("enrollmentWebClient")
+    public WebClient enrollmentWebClient() {
+
+	    HttpClient httpClient= HttpClient.create().secure(t -> t.sslContext(getSSLContext()));
+		ClientHttpConnector connector= new ReactorClientHttpConnector(httpClient);
+	    
+		return WebClient.builder()
+	    		.clientConnector(connector)
+                .baseUrl(r50Url)
+                .filter(logRequest())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE) 
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.ALL_VALUE) 
+                .defaultHeaders(header -> header.setBasicAuth(userName, userPassword))
+                .build();
+    }
+
+	private SslContext getSSLContext() {
+
+	    try {
+	        KeyStore keyStore = KeyStore.getInstance(KEY_STORE_TYPE_PKCS12);
+	        keyStore.load(new FileInputStream(certFile.getFile()), certPassword.toCharArray());
+
+	        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KEY_MANAGER_FACTORY_TYPE_SUN_X509);
+	        keyManagerFactory.init(keyStore, certPassword.toCharArray());
+
+	        return SslContextBuilder.forClient()
+	                .keyManager(keyManagerFactory)
+	                .build();
+
+	    } catch (Exception e) {
+	        logger.error("Error creating Enroll Subscriber WebClient SSL Context.");	        
+	    }
+
+	    return null;
+	}
+	
+    /*
+     * Log request details for the downstream web service calls
+     */
+    private ExchangeFilterFunction logRequest() {
+        return ExchangeFilterFunction.ofRequestProcessor(c -> {
+        	logger.debug("Request: {} {}", c.method(), c.url());
+            c.headers().forEach((n, v) -> logger.debug("request header: {}={}", n, v));
+            return Mono.just(c);
+        });
+    }
+}

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/config/WebClientConfig.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/config/WebClientConfig.java
@@ -32,7 +32,7 @@ import reactor.netty.http.client.HttpClient;
 @Configuration
 public class WebClientConfig {
 
-	private final Logger logger = LoggerFactory.getLogger("WebClientConfig");
+	private final Logger logger = LoggerFactory.getLogger(WebClientConfig.class);
 
 	private static final String KEY_STORE_TYPE_PKCS12 = "pkcs12";
 

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EligibilityController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EligibilityController.java
@@ -20,7 +20,7 @@ import ca.bc.gov.hlth.hnweb.model.CheckEligibilityResponse;
 public class EligibilityController {
 	private static final Logger logger = LoggerFactory.getLogger(EligibilityController.class);
 
-	@GetMapping("/check-eligibility")
+	@GetMapping("/checkEligibility")
 	public ResponseEntity<CheckEligibilityResponse> checkEligibility(@RequestParam(name = "phn", required = true) String phn,
 			@DateTimeFormat(iso = ISO.DATE) @RequestParam(name = "eligibilityDate", required = false) Date eligibilityDate) {
 		logger.info("checkEligibility request - phn: {} date: {}", phn, eligibilityDate);

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EligibilityController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EligibilityController.java
@@ -20,7 +20,7 @@ import ca.bc.gov.hlth.hnweb.model.CheckEligibilityResponse;
 public class EligibilityController {
 	private static final Logger logger = LoggerFactory.getLogger(EligibilityController.class);
 
-	@GetMapping("/checkEligibility")
+	@GetMapping("/check-eligibility")
 	public ResponseEntity<CheckEligibilityResponse> checkEligibility(@RequestParam(name = "phn", required = true) String phn,
 			@DateTimeFormat(iso = ISO.DATE) @RequestParam(name = "eligibilityDate", required = false) Date eligibilityDate) {
 		logger.info("checkEligibility request - phn: {} date: {}", phn, eligibilityDate);

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentController.java
@@ -40,13 +40,13 @@ public class EnrollmentController {
 	@Autowired
 	private EnrollmentService enrollmentService;
 	
-	@PostMapping("/enrollsubscriber")
+	@PostMapping("/enroll-subscriber")
 	public EnrollSubscriberResponse enrollSubscriber(@Valid @RequestBody EnrollSubscriberRequest enrollSubscriberRequest) throws HL7Exception, IOException {
 		
 		logger.info("Subscriber enroll request: {} ", enrollSubscriberRequest.getPhn());
 		
 		R50 r50 = convertEnrollSubscriberRequestToR50(enrollSubscriberRequest);		
-		final String transactionId = UUID.randomUUID().toString();		
+		String transactionId = UUID.randomUUID().toString();		
 		Message message = enrollmentService.enrollSubscriber(r50, transactionId);		
 		EnrollSubscriberResponse enrollSubscriberResponse = convertAckToEnrollSubscriberResponse(message);
 		

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentController.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.hlth.hnweb.controller;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import javax.validation.Valid;
 
@@ -44,13 +45,9 @@ public class EnrollmentController {
 		
 		logger.info("Subscriber enroll request: {} ", enrollSubscriberRequest.getPhn());
 		
-		//Convert request to R50 message and get it as HL7 v2 String. (This message is used to send to external endpoint wrapped in JSON)
-		R50 r50 = convertEnrollSubscriberRequestToR50(enrollSubscriberRequest);
-		
-		//Send to R50 endpoint
-		Message message = enrollmentService.enrollSubscriber(r50);
-		
-		//Convert R50 endpoint response to HN Web response
+		R50 r50 = convertEnrollSubscriberRequestToR50(enrollSubscriberRequest);		
+		final String transactionId = UUID.randomUUID().toString();		
+		Message message = enrollmentService.enrollSubscriber(r50, transactionId);		
 		EnrollSubscriberResponse enrollSubscriberResponse = convertAckToEnrollSubscriberResponse(message);
 		
 		logger.info("Subscriber enroll Response: {} ", enrollSubscriberResponse.getAcknowledgementMessage());
@@ -83,6 +80,8 @@ public class EnrollmentController {
     	String messageId = terser.get("/.MSH-10-1");
     	String acknowledgementCode = terser.get("/.MSA-1-1");
     	String acknowledgementMessage = terser.get("/.MSA-3-1");
+    	
+    	logger.debug("ACK message response code [{}] and message [{}]", acknowledgementCode, acknowledgementMessage);
     	
     	enrollSubscriberResponse.setMessageId(messageId);
     	enrollSubscriberResponse.setAcknowledgementCode(acknowledgementCode);

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/exception/HNWebException.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/exception/HNWebException.java
@@ -1,0 +1,27 @@
+package ca.bc.gov.hlth.hnweb.exception;
+
+public class HNWebException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public HNWebException() {
+		super();
+	}
+
+	public HNWebException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public HNWebException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public HNWebException(String message) {
+		super(message);
+	}
+
+	public HNWebException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/EnrollmentService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/EnrollmentService.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -33,21 +31,6 @@ public class EnrollmentService {
 	@Autowired
 	private WebClient enrollmentWebClient;
 	
-	@Value("${R50.url}")
-	private String r50Url;
-
-	@Value("${R50.user.name}")
-	private String userName;
-
-	@Value("${R50.user.password}")
-	private String userPassword;
-
-	@Value("classpath:${R50.cert.file}")
-	private Resource certFile;
-
-	@Value("${R50.cert.password}")
-	private String certPassword;
-
 	/**
 	 * Enrolls a subscriber by sending a HL7 V2 message to external enrollment service. It was the R50 message to create a V2 String and sends this
 	 * over Https using TLS. The endpoint also requires Basic Authentication. 
@@ -66,14 +49,14 @@ public class EnrollmentService {
 		String r50v2RequiredFormat = formatMessage(r50v2);
 		logger.debug("Updated V2 message:\n{}", r50v2RequiredFormat);
 		
-		ResponseEntity<String> response = postEnrollmentRequest(r50Url, r50v2RequiredFormat, transactionId);
+		ResponseEntity<String> response = postEnrollmentRequest(r50v2RequiredFormat, transactionId);
 		
 		logger.debug("Response Status: {} ; Message:\n{}", response.getStatusCode(), response.getBody());
 		
 		return parseR50v2ToAck(response.getBody());
 	}
 
-	private ResponseEntity<String> postEnrollmentRequest(String path, String data, String transactionId) {
+	private ResponseEntity<String> postEnrollmentRequest(String data, String transactionId) {
         return enrollmentWebClient
                 .post()
                 .contentType(MediaType.TEXT_PLAIN)
@@ -84,7 +67,7 @@ public class EnrollmentService {
                 .block();
     }	
 	
-    private String encodeR50ToV2(R50 r50) throws HL7Exception, IOException {
+    private String encodeR50ToV2(R50 r50) throws HL7Exception {
     	
     	// Encode the message using the default HAPI parser and return it as a String
     	String encodedMessage = parser.encode(r50);
@@ -115,8 +98,7 @@ public class EnrollmentService {
 	 * @return
 	 */
 	private String formatMessage(String r50v2) {
-		String r50v2RequiredFormat = r50v2.replaceFirst("\r", "||\r");
-		return r50v2RequiredFormat;
+		return  r50v2.replaceFirst("\r", "||\r");
 	}
 	
 }

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/EnrollmentService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/EnrollmentService.java
@@ -1,10 +1,19 @@
 package ca.bc.gov.hlth.hnweb.service;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import ca.bc.gov.hlth.hnweb.model.v2.message.R50;
 import ca.uhn.hl7v2.HL7Exception;
@@ -20,28 +29,93 @@ public class EnrollmentService {
 
 	private static final Logger logger = org.slf4j.LoggerFactory.getLogger(EnrollmentService.class);
 
+	public static String TRANSACTION_ID = "TransactionID";
+
 	@Autowired
 	private Parser parser;
+    
+	@Autowired
+	private WebClient enrollmentWebClient;
 	
-	public Message enrollSubscriber(R50 r50) throws HL7Exception, IOException {
-		
-		logger.debug("Enroll subscriber");
+	@Value("${R50.url}")
+	private String r50Url;
 
-		String r50v2 = encodeR50ToV2(r50);
+	@Value("${R50.user.name}")
+	private String userName;
+
+	@Value("${R50.user.password}")
+	private String userPassword;
+
+	@Value("classpath:${R50.cert.file}")
+	private Resource certFile;
+
+	@Value("${R50.cert.password}")
+	private String certPassword;
+
+	@Autowired
+	private RestTemplate enrollmentRestTemplate;
+
+	/**
+	 * Enrolls a subscriber by sending a HL7 V2 message to external enrollment service. It was the R50 message to create a V2 String and sends this
+	 * over Https using TLS. The endpoint also requires Basic Authentication. 
+	 * 
+	 * @param r50
+	 * @param transactionId
+	 * @return
+	 * @throws HL7Exception
+	 * @throws IOException
+	 */
+	public Message enrollSubscriber(R50 r50, String transactionId) throws HL7Exception, IOException {
 		
-	    //TODO (daveb-hni) Add the code to send to external endpoint
+		logger.debug("Enroll subscriber for Message ID [{}]; Transaction ID [{}]", r50.getMSH().getMsh10_MessageControlID(), transactionId);
+
+		String r50v2 = encodeR50ToV2(r50);		
+		String r50v2RequiredFormat = formatMessage(r50v2);
+		logger.debug("Updated V2 message:\n{}", r50v2RequiredFormat);
 		
-		//Return stubbed response.
-		return parseR50v2ToAck("MSH|^~\\&|RAIPRSN-NM-SRCH|BC00002041|HNWeb|moh_hnclient_dev|20211013124847.746-0700||ACK|71902|D|2.4\r\n" + 
-				"MSA|AE|20191108082211|NHR529E^SEVERE SYSTEM ERROR\r\n" + 
-				"ERR|^^^NHR529E");
+		ResponseEntity<String> response = postEnrollmentRequest(r50Url, r50v2RequiredFormat, transactionId);		
+//		ResponseEntity<String> response = sendEnrollmentRequest(r50v2RequiredFormat, transactionId);
+		
+		logger.debug("Response Status: {} ; Message:\n{}", response.getStatusCode(), response.getBody());
+		
+		return parseR50v2ToAck(response.getBody());
 	}
+
+	private ResponseEntity<String> postEnrollmentRequest(String path, String data, String transactionId) {
+        return enrollmentWebClient
+                .post()
+                .contentType(MediaType.TEXT_PLAIN)
+                .header(TRANSACTION_ID, transactionId)
+                .bodyValue(data)
+                .retrieve()
+                .toEntity(String.class)
+                .block();
+    }	
+	
+	/*
+	 * Uses a RestTemplate to post a request with the required headers and body 
+	 */
+	private ResponseEntity<String> sendEnrollmentRequest(String v2, String transactionId) {
+
+	    HttpHeaders headers = setRequestHeaders(transactionId);	    
+	    HttpEntity<String> entity = new HttpEntity<String>(v2, headers);	    
+	    return enrollmentRestTemplate.postForEntity(r50Url, entity, String.class);
+	}
+
+	private HttpHeaders setRequestHeaders(String transactionId) {
 		
+		HttpHeaders headers = new HttpHeaders();
+	    headers.setContentType(MediaType.TEXT_PLAIN);
+	    headers.setAccept(Collections.singletonList(MediaType.ALL));
+		headers.set(TRANSACTION_ID, transactionId);
+		return headers;
+	}
+	
     private String encodeR50ToV2(R50 r50) throws HL7Exception, IOException {
     	
     	// Encode the message using the default HAPI parser and return it as a String
     	String encodedMessage = parser.encode(r50);
-    	logger.debug("R50 Encoded Message: {}", encodedMessage);
+    	logger.debug("R50 Encoded Message:\n{}", encodedMessage);
     	
     	return encodedMessage;
     }
@@ -55,4 +129,21 @@ public class EnrollmentService {
     	return message;
     }
     
+	/**
+	 * TODO (daveb-hni) The message is currently being adjusted to avoid an error in the endpoint. Confirm if this is needed when a response is received to the email that has been sent to the endpoint creator. 
+	 * The endpoint currently expects the message in slightly different format to the HL7 V2 2.4 spec. The difference in the messages is that there is an empty field expected 
+	 * at the end of the MSH Segment after the Version field. e.g.
+	 * MSH|^~\\&|HNWeb|BC01000030|RAIENROL-EMP|BC00001013|20200529114230|10-TEST|R50^Z06|20200529114230|D|2.4||
+
+		versus the spec version
+
+	 * MSH|^~\\&|HNWeb|BC01000030|RAIENROL-EMP|BC00001013|20200529114230|10-ANother|R50^Z06|20200529114230|D|2.4
+	 * @param r50v2
+	 * @return
+	 */
+	private String formatMessage(String r50v2) {
+		String r50v2RequiredFormat = r50v2.replaceFirst("\r", "||\r");
+		return r50v2RequiredFormat;
+	}
+	
 }

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/EnrollmentService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/EnrollmentService.java
@@ -23,7 +23,7 @@ public class EnrollmentService {
 
 	private static final Logger logger = org.slf4j.LoggerFactory.getLogger(EnrollmentService.class);
 
-	public static String TRANSACTION_ID = "TransactionID";
+	public static final String TRANSACTION_ID = "TransactionID";
 
 	@Autowired
 	private Parser parser;

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/EnrollmentService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/EnrollmentService.java
@@ -1,18 +1,14 @@
 package ca.bc.gov.hlth.hnweb.service;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import ca.bc.gov.hlth.hnweb.model.v2.message.R50;
@@ -52,9 +48,6 @@ public class EnrollmentService {
 	@Value("${R50.cert.password}")
 	private String certPassword;
 
-	@Autowired
-	private RestTemplate enrollmentRestTemplate;
-
 	/**
 	 * Enrolls a subscriber by sending a HL7 V2 message to external enrollment service. It was the R50 message to create a V2 String and sends this
 	 * over Https using TLS. The endpoint also requires Basic Authentication. 
@@ -73,8 +66,7 @@ public class EnrollmentService {
 		String r50v2RequiredFormat = formatMessage(r50v2);
 		logger.debug("Updated V2 message:\n{}", r50v2RequiredFormat);
 		
-		ResponseEntity<String> response = postEnrollmentRequest(r50Url, r50v2RequiredFormat, transactionId);		
-//		ResponseEntity<String> response = sendEnrollmentRequest(r50v2RequiredFormat, transactionId);
+		ResponseEntity<String> response = postEnrollmentRequest(r50Url, r50v2RequiredFormat, transactionId);
 		
 		logger.debug("Response Status: {} ; Message:\n{}", response.getStatusCode(), response.getBody());
 		
@@ -91,25 +83,6 @@ public class EnrollmentService {
                 .toEntity(String.class)
                 .block();
     }	
-	
-	/*
-	 * Uses a RestTemplate to post a request with the required headers and body 
-	 */
-	private ResponseEntity<String> sendEnrollmentRequest(String v2, String transactionId) {
-
-	    HttpHeaders headers = setRequestHeaders(transactionId);	    
-	    HttpEntity<String> entity = new HttpEntity<String>(v2, headers);	    
-	    return enrollmentRestTemplate.postForEntity(r50Url, entity, String.class);
-	}
-
-	private HttpHeaders setRequestHeaders(String transactionId) {
-		
-		HttpHeaders headers = new HttpHeaders();
-	    headers.setContentType(MediaType.TEXT_PLAIN);
-	    headers.setAccept(Collections.singletonList(MediaType.ALL));
-		headers.set(TRANSACTION_ID, transactionId);
-		return headers;
-	}
 	
     private String encodeR50ToV2(R50 r50) throws HL7Exception, IOException {
     	

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,10 +1,3 @@
-keycloak:
-  base-oauth-url: https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications
-
-config:
-  # CORS header, should be HNWeb:
-  allowed-origins: http://localhost:3000
-
 spring:
   profiles:
     active: dev
@@ -20,15 +13,3 @@ springdoc:
     path: /docs/swagger-ui.html
   api-docs:
     path: /docs/api-docs
-
-server:
-  port: 9090
-  
-R50:
-  url: 
-  user: 
-    name: 
-    password: 
-  cert:
-    file: 
-    password: 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -23,3 +23,12 @@ springdoc:
 
 server:
   port: 9090
+  
+R50:
+  url: 
+  user: 
+    name: 
+    password: 
+  cert:
+    file: 
+    password: 

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentControllerTest.java
@@ -1,37 +1,89 @@
 package ca.bc.gov.hlth.hnweb.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 import ca.bc.gov.hlth.hnweb.model.EnrollSubscriberRequest;
 import ca.bc.gov.hlth.hnweb.model.EnrollSubscriberResponse;
-import ca.uhn.hl7v2.HL7Exception;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
+/**
+ * Junit test class for EnrollmentController
+ *
+ */
 @SpringBootTest
 public class EnrollmentControllerTest {
+
+	private static final String ACK = "MSH|^~\\&|RAIPRSN-NM-SRCH|BC00002041|HNWeb|moh_hnclient_dev|20211013124847.746-0700||ACK|71902|D|2.4\r\n" + 
+			"MSA|AE|20191108082211|NHR529E^SEVERE SYSTEM ERROR\r\n" + 
+			"ERR|^^^NHR529E";
+
+	public static MockWebServer mockBackEnd;
 
 	@Autowired
 	private EnrollmentController enrollmentController;
 	
-	@Test
-	public void testEnrollSubscriber_Error() throws HL7Exception, IOException {
+	@BeforeAll
+    static void setUp() throws IOException {
+        mockBackEnd = new MockWebServer();
+        mockBackEnd.start(0);
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockBackEnd.shutdown();
+    }
+    
+    @Test
+    void testEnrollSubscriber_Error() throws Exception {    	
+        
+        mockBackEnd.enqueue(new MockResponse()
+        		.setBody(ACK)
+        	    .addHeader(CONTENT_TYPE, MediaType.TEXT_PLAIN.toString()));
+
 		EnrollSubscriberRequest enrollSubscriberRequest = createEnrollSubscriberRequest();
 		EnrollSubscriberResponse enrollSubscriberResponse = enrollmentController.enrollSubscriber(enrollSubscriberRequest);
-		
-		assertEquals("AE", enrollSubscriberResponse.getAcknowledgementCode());
-	}
 
-	private EnrollSubscriberRequest createEnrollSubscriberRequest() {
+		//Check the response
+		assertEquals("AE", enrollSubscriberResponse.getAcknowledgementCode());
+		assertEquals("NHR529E", enrollSubscriberResponse.getAcknowledgementMessage());
+		
+		//Check the client request is sent as expected
+        RecordedRequest recordedRequest = mockBackEnd.takeRequest();        
+        assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
+        assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
+        assertEquals("/", recordedRequest.getPath());
+    }
+    
+    /**
+     * The URL property used by the mocked endpoint needs to be set after the MockWebServer starts as the port it uses is 
+     * created dynamically on start up to ensure it uses an available port so it is not known before then. 
+     * @param registry
+     */
+    @DynamicPropertySource
+    static void registerMockUrlProperty(DynamicPropertyRegistry registry) {
+        registry.add("R50.url", () -> String.format("http://localhost:%s", mockBackEnd.getPort()));
+    }
+    
+    private EnrollSubscriberRequest createEnrollSubscriberRequest() {
 		EnrollSubscriberRequest enrollSubscriberRequest = new EnrollSubscriberRequest();
 		enrollSubscriberRequest.setPhn("123456789");
 		enrollSubscriberRequest.setSurname("Test");
 		enrollSubscriberRequest.setGender("M");
 		return enrollSubscriberRequest;
 	}
-
 }

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentControllerTest.java
@@ -22,7 +22,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
 /**
- * Junit test class for EnrollmentController
+ * JUnit test class for EnrollmentController
  *
  */
 @SpringBootTest


### PR DESCRIPTION
Added connection for consuming an external endpoint using Spring WebClient. This includes:

- Adding dependency
- Adding connection properties
- Setting up the WebClient connection as a Spring Bean
- Sending to sample enrollment endpoint.