### PR TITLE
Added page for unauthorized user access

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,7 +10,7 @@
 
 <template>
   <TheHeader/>
-  <TheNavBar v-if="isHNWebPage"/>
+  <TheNavBar v-if="isAuthorized"/>
   <main>
     <section class="content">
       <TheAlert/>
@@ -18,7 +18,7 @@
     </section>
     <KeycloakDevTools v-if="dev"/>
   </main>
-  <TheFooter v-if="isHNWebPage"/>
+  <TheFooter v-if="isAuthorized"/>
 </template>
 
 <script>
@@ -30,7 +30,7 @@
       }
     },
     computed: {
-      isHNWebPage() {
+      isAuthorized() {
         return this.$route.name !== 'Unauthorized'
       }
     }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,7 +10,7 @@
 
 <template>
   <TheHeader/>
-  <TheNavBar/>
+  <TheNavBar v-if="isHNWebPage"/>
   <main>
     <section class="content">
       <TheAlert/>
@@ -18,7 +18,7 @@
     </section>
     <KeycloakDevTools v-if="dev"/>
   </main>
-  <TheFooter/>
+  <TheFooter v-if="isHNWebPage"/>
 </template>
 
 <script>
@@ -29,6 +29,11 @@
         dev: import.meta.env.DEV,
       }
     },
+    computed: {
+      isHNWebPage() {
+        return this.$route.name !== 'Unauthorized'
+      }
+    }
   }
 </script>
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -144,15 +144,11 @@ const router = createRouter({
 
 router.beforeEach((to, from, next) => {
   const hasAnyPermission = store.getters['auth/hasAnyPermission']
-  if (hasAnyPermission || isUnauthorizedComponent(to)) {
+  if (hasAnyPermission || to.name === 'Unauthorized') {
     next()
   } else {
     next({ name: 'Unauthorized' })
   }
 })
-
-function isUnauthorizedComponent(to) {
-  return to.name === 'Unauthorized'
-}
 
 export default router

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -13,6 +13,8 @@ import Home from './../views/Home.vue'
 import NotFound from '../views/NotFound.vue'
 import PhnInquiry from '../views/eligibility/PhnInquiry.vue'
 import PhnLookup from '../views/eligibility/PhnLookup.vue'
+import Unauthorized from '../views/Unauthorized.vue'
+import keycloak from '../keycloak'
 import store from '../store'
 
 const routes = [
@@ -103,6 +105,11 @@ const routes = [
     name: 'NotFound',
     component: NotFound,
   },
+  {
+    path: '/unauthorized',
+    name: 'Unauthorized',
+    component: Unauthorized,
+  },
 ]
 
 function checkPageAction(to, next) {
@@ -134,5 +141,18 @@ const router = createRouter({
     return { left: 0, top: 0 }
   },
 })
+
+router.beforeEach((to, from, next) => {
+  const hasAnyPermission = store.getters['auth/hasAnyPermission']
+  if (hasAnyPermission || isUnauthorizedComponent(to)) {
+    next()
+  } else {
+    next({ name: 'Unauthorized' })
+  }
+})
+
+function isUnauthorizedComponent(to) {
+  return to.name === 'Unauthorized'
+}
 
 export default router

--- a/frontend/src/store/modules/auth.js
+++ b/frontend/src/store/modules/auth.js
@@ -14,13 +14,16 @@ const getters = {
   },
   hasPermission: (state) => (permission) => {
     return state.permissions.includes(permission)
-  }
+  },
+  hasAnyPermission: (state) => {
+    return state.permissions.length > 0
+  },
 }
 
 const actions = {
   setPermissions(context, permissions) {
     context.commit('setPermissions', permissions)
-  }
+  },
 }
 
 export default {
@@ -28,5 +31,5 @@ export default {
   state,
   getters,
   mutations,
-  actions
+  actions,
 }

--- a/frontend/src/views/Unauthorized.vue
+++ b/frontend/src/views/Unauthorized.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <H1>Access Denied</H1>
+    <h1>Access Denied</h1>
     <p>We're sorry, but you do not have access to the requested resource</p>
     <p>
       Please contact the Help Desk if you require further assistance<br />

--- a/frontend/src/views/Unauthorized.vue
+++ b/frontend/src/views/Unauthorized.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <H1>Access Denied</H1>
+    <p>We're sorry, but you do not have access to the requested resource</p>
+    <p>
+      Please contact the Help Desk if you require further assistance<br />
+      Phone number: 250-387-7000<br />
+      Email: 77000@gov.bc.ca
+    </p>
+  </div>
+</template>
+<script>
+export default {
+  name: 'Unauthorized',
+}
+</script>


### PR DESCRIPTION
On access to any screen users with BC Gov account but no HN Web roles will be directed to a default unauthorized page. Added:

- validation guard in the route 
- a default page.
- hiding of menu and footer