### PR TITLE
5814 duplicate affected party records per transaction

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/BaseController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/BaseController.java
@@ -10,6 +10,7 @@ import org.springframework.web.reactive.function.client.WebClientException;
 import org.springframework.web.server.ResponseStatusException;
 
 import ca.bc.gov.hlth.hnweb.exception.HNWebException;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.persistence.entity.ErrorLevel;
 import ca.bc.gov.hlth.hnweb.persistence.entity.IdentifierType;
 import ca.bc.gov.hlth.hnweb.persistence.entity.Transaction;
@@ -44,8 +45,8 @@ public abstract class BaseController {
 	 * @param type The type of identifier. E.g. PHN
 	 * @param identifier The value of the identifier
 	 */
-	protected void addAffectedParty(Transaction transaction, IdentifierType type, String identifier) {
-		auditService.createAffectedParty(transaction, type, identifier);
+	protected void addAffectedParty(Transaction transaction, IdentifierType type, String identifier, AffectedPartyDirection direction) {
+		auditService.createAffectedParty(transaction, type, identifier, direction);
 	}
 	
 	/**

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EligibilityController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EligibilityController.java
@@ -29,6 +29,7 @@ import ca.bc.gov.hlth.hnweb.model.rest.eligibility.LookupPhnRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.eligibility.LookupPhnResponse;
 import ca.bc.gov.hlth.hnweb.model.v2.message.E45;
 import ca.bc.gov.hlth.hnweb.model.v2.message.R15;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.persistence.entity.IdentifierType;
 import ca.bc.gov.hlth.hnweb.persistence.entity.Transaction;
 import ca.bc.gov.hlth.hnweb.security.TransactionType;
@@ -60,7 +61,7 @@ public class EligibilityController extends BaseController {
 	@PostMapping("/check-eligibility")
 	public ResponseEntity<CheckEligibilityResponse> checkEligibility(@Valid @RequestBody CheckEligibilityRequest checkEligibilityRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.CHECK_ELIGIBILITY);
-		addAffectedParty(transaction, IdentifierType.PHN, checkEligibilityRequest.getPhn());
+		addAffectedParty(transaction, IdentifierType.PHN, checkEligibilityRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
 
 		try {
 			R15Converter converter = new R15Converter(mshDefaults);
@@ -73,7 +74,7 @@ public class EligibilityController extends BaseController {
 			logger.info("checkEligibility response: {} ", checkEligibilityResponse);
 			
 			transactionComplete(transaction);
-			addAffectedParty(transaction, IdentifierType.PHN, checkEligibilityResponse.getPhn());
+			addAffectedParty(transaction, IdentifierType.PHN, checkEligibilityResponse.getPhn(), AffectedPartyDirection.INBOUND);
 
 			return response;	
 		} catch (Exception e) {
@@ -92,7 +93,7 @@ public class EligibilityController extends BaseController {
 	@PostMapping("/inquire-phn")
 	public ResponseEntity<InquirePhnResponse> inquirePhn(@Valid @RequestBody InquirePhnRequest inquirePhnRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.PHN_INQUIRY);
-		inquirePhnRequest.getPhns().forEach(phn -> addAffectedParty(transaction, IdentifierType.PHN, phn));		
+		inquirePhnRequest.getPhns().forEach(phn -> addAffectedParty(transaction, IdentifierType.PHN, phn, AffectedPartyDirection.OUTBOUND));		
 
 		try {
 			RPBSPPE0Converter converter = new RPBSPPE0Converter();
@@ -106,7 +107,7 @@ public class EligibilityController extends BaseController {
 			logger.info("inquirePHN response: {} ", inquirePhnResponse);
 
 			transactionComplete(transaction);
-			inquirePhnResponse.getBeneficiaries().forEach(beneficiary -> addAffectedParty(transaction, IdentifierType.PHN, beneficiary.getPhn()));
+			inquirePhnResponse.getBeneficiaries().forEach(beneficiary -> addAffectedParty(transaction, IdentifierType.PHN, beneficiary.getPhn(), AffectedPartyDirection.INBOUND));
 
 			return response;	
 		} catch (Exception e) {
@@ -125,8 +126,8 @@ public class EligibilityController extends BaseController {
 	@PostMapping("/lookup-phn")
 	public ResponseEntity<LookupPhnResponse> lookupPhn(@Valid @RequestBody LookupPhnRequest lookupPhnRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.PHN_LOOKUP);
-		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, lookupPhnRequest.getGroupNumber());
-		addAffectedParty(transaction, IdentifierType.CONTRACT_NUMBER, lookupPhnRequest.getContractNumber());
+		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, lookupPhnRequest.getGroupNumber(), AffectedPartyDirection.OUTBOUND);
+		addAffectedParty(transaction, IdentifierType.CONTRACT_NUMBER, lookupPhnRequest.getContractNumber(), AffectedPartyDirection.OUTBOUND);
 
 		try {
 			RPBSPPL0Converter converter = new RPBSPPL0Converter();
@@ -140,7 +141,7 @@ public class EligibilityController extends BaseController {
 			logger.info("lookupPhn response: {} ", lookupPhnResponse);
 			
 			transactionComplete(transaction);
-			lookupPhnResponse.getBeneficiaries().forEach(beneficiary -> addAffectedParty(transaction, IdentifierType.PHN, beneficiary.getPhn()));
+			lookupPhnResponse.getBeneficiaries().forEach(beneficiary -> addAffectedParty(transaction, IdentifierType.PHN, beneficiary.getPhn(), AffectedPartyDirection.INBOUND));
 			
 			return response;	
 		} catch (Exception e) {
@@ -159,7 +160,7 @@ public class EligibilityController extends BaseController {
 	@PostMapping("/check-msp-coverage-status")
 	public ResponseEntity<CheckMspCoverageStatusResponse> checkMspCoverageStatus(@Valid @RequestBody CheckMspCoverageStatusRequest checkMspCoverageStatusRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.MSP_COVERAGE_STATUS_CHECK);
-		addAffectedParty(transaction, IdentifierType.PHN, checkMspCoverageStatusRequest.getPhn());
+		addAffectedParty(transaction, IdentifierType.PHN, checkMspCoverageStatusRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
 
 		try {
 			E45Converter converter = new E45Converter(mshDefaults);
@@ -172,7 +173,7 @@ public class EligibilityController extends BaseController {
 			logger.info("checkEligibility response: {} ", coverageResponse);
 			
 			transactionComplete(transaction);
-			addAffectedParty(transaction, IdentifierType.PHN, coverageResponse.getPhn());
+			addAffectedParty(transaction, IdentifierType.PHN, coverageResponse.getPhn(), AffectedPartyDirection.INBOUND);
 			
 			return response;	
 		} catch (Exception e) {

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentController.java
@@ -28,6 +28,7 @@ import ca.bc.gov.hlth.hnweb.model.v3.FindCandidatesRequest;
 import ca.bc.gov.hlth.hnweb.model.v3.FindCandidatesResponse;
 import ca.bc.gov.hlth.hnweb.model.v3.GetDemographicsRequest;
 import ca.bc.gov.hlth.hnweb.model.v3.GetDemographicsResponse;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.persistence.entity.IdentifierType;
 import ca.bc.gov.hlth.hnweb.persistence.entity.Transaction;
 import ca.bc.gov.hlth.hnweb.security.TransactionType;
@@ -87,7 +88,7 @@ public class EnrollmentController extends BaseController {
 		logger.info("Demographic request: {} ", personDetailsRequest.getPhn());
 
 		Transaction transaction = transactionStart(request, TransactionType.GET_PERSON_DETAILS);
-		addAffectedParty(transaction, IdentifierType.PHN, personDetailsRequest.getPhn());
+		addAffectedParty(transaction, IdentifierType.PHN, personDetailsRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
 
 		try {
 			GetDemographicsConverter converter = new GetDemographicsConverter();
@@ -133,14 +134,14 @@ public class EnrollmentController extends BaseController {
 		Transaction transaction = transactionStart(request, TransactionType.ENROLL_SUBSCRIBER);		
 		//Some requests do not contain the PHN e.g R50 z05 as it is Enroll subscriber without PHN
 		if (StringUtils.isNotBlank(enrollSubscriberRequest.getPhn())) {
-			addAffectedParty(transaction, IdentifierType.PHN, enrollSubscriberRequest.getPhn());
+			addAffectedParty(transaction, IdentifierType.PHN, enrollSubscriberRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
 		}
-		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, enrollSubscriberRequest.getGroupNumber());
+		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, enrollSubscriberRequest.getGroupNumber(), AffectedPartyDirection.OUTBOUND);
 		if (StringUtils.isNotBlank(enrollSubscriberRequest.getGroupMemberNumber())) {
-			addAffectedParty(transaction, IdentifierType.GROUP_MEMBER_NUMBER, enrollSubscriberRequest.getGroupMemberNumber());
+			addAffectedParty(transaction, IdentifierType.GROUP_MEMBER_NUMBER, enrollSubscriberRequest.getGroupMemberNumber(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(enrollSubscriberRequest.getDepartmentNumber())) {
-			addAffectedParty(transaction, IdentifierType.DEPARTMENT_NUMBER, enrollSubscriberRequest.getDepartmentNumber());
+			addAffectedParty(transaction, IdentifierType.DEPARTMENT_NUMBER, enrollSubscriberRequest.getDepartmentNumber(), AffectedPartyDirection.OUTBOUND);
 		}
 		return transaction;
 	}
@@ -150,21 +151,21 @@ public class EnrollmentController extends BaseController {
 		transactionComplete(transaction);
 		//Some responses do not contain the PHN e.g. in the case of R50 z06 it is just an ACK
 		if (StringUtils.isNotBlank(enrollSubscriberResponse.getPhn())) {
-			addAffectedParty(transaction, IdentifierType.PHN, enrollSubscriberResponse.getPhn());
+			addAffectedParty(transaction, IdentifierType.PHN, enrollSubscriberResponse.getPhn(), AffectedPartyDirection.INBOUND);
 		}
 	}
 
 	private void auditGetPersonSearchComplete(Transaction transaction, GetPersonDetailsResponse personDetailsResponse) {
 		transactionComplete(transaction);
 		if (StringUtils.isNotBlank(personDetailsResponse.getPhn())) {
-			addAffectedParty(transaction, IdentifierType.PHN, personDetailsResponse.getPhn());
+			addAffectedParty(transaction, IdentifierType.PHN, personDetailsResponse.getPhn(), AffectedPartyDirection.INBOUND);
 		}
 	}
 
 	private void auditGetNameSearchComplete(Transaction transaction, NameSearchResponse nameSearchResponse) {
 		transactionComplete(transaction);
 		if (nameSearchResponse.getCandidates() != null) {
-			nameSearchResponse.getCandidates().forEach(candidate -> addAffectedParty(transaction, IdentifierType.PHN, candidate.getPhn()));
+			nameSearchResponse.getCandidates().forEach(candidate -> addAffectedParty(transaction, IdentifierType.PHN, candidate.getPhn(), AffectedPartyDirection.INBOUND));
 		}
 	}
 

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/GroupMemberController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/GroupMemberController.java
@@ -41,6 +41,7 @@ import ca.bc.gov.hlth.hnweb.model.rest.groupmember.CancelGroupMemberRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.groupmember.CancelGroupMemberResponse;
 import ca.bc.gov.hlth.hnweb.model.rest.groupmember.UpdateNumberAndDeptRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.groupmember.UpdateNumberAndDeptResponse;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.persistence.entity.IdentifierType;
 import ca.bc.gov.hlth.hnweb.persistence.entity.Transaction;
 import ca.bc.gov.hlth.hnweb.security.TransactionType;
@@ -82,7 +83,7 @@ public class GroupMemberController extends BaseController {
 			logger.info("addDependentResponse response: {} ", addDependentResponse);
 			
 			transactionComplete(transaction);
-			addAffectedParty(transaction, IdentifierType.PHN, addDependentResponse.getPhn());
+			addAffectedParty(transaction, IdentifierType.PHN, addDependentResponse.getPhn(), AffectedPartyDirection.INBOUND);
 			
 			return response;
 		} catch (Exception e) {
@@ -135,7 +136,7 @@ public class GroupMemberController extends BaseController {
 			logger.info("updateNumberAndDept response: {} ", updateNumberAndDeptResponse);
 
 			transactionComplete(transaction);
-			addAffectedParty(transaction, IdentifierType.PHN, updateNumberAndDeptResponse.getPhn());
+			addAffectedParty(transaction, IdentifierType.PHN, updateNumberAndDeptResponse.getPhn(), AffectedPartyDirection.INBOUND);
 			
 			return response;
 		} catch (Exception e) {
@@ -168,7 +169,7 @@ public class GroupMemberController extends BaseController {
 			logger.info("addGroupMemberResponse response: {} ", addGroupMemberResponse);
 			
 			transactionComplete(transaction);
-			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberResponse.getPhn());
+			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberResponse.getPhn(), AffectedPartyDirection.INBOUND);
 
 			return response;
 		} catch (Exception e) {
@@ -201,7 +202,7 @@ public class GroupMemberController extends BaseController {
 			logger.info("cancelGroupMemberResponse response: {} ", cancelGroupMemberResponse);
 
 			transactionComplete(transaction);
-			addAffectedParty(transaction, IdentifierType.PHN, cancelGroupMemberResponse.getPhn());
+			addAffectedParty(transaction, IdentifierType.PHN, cancelGroupMemberResponse.getPhn(), AffectedPartyDirection.INBOUND);
 
 			return response;	
 		} catch (Exception e) {
@@ -234,7 +235,7 @@ public class GroupMemberController extends BaseController {
 			logger.info("CancelDependentResponse response: {} ", cancelDependentResponse);
 			
 			transactionComplete(transaction);
-			addAffectedParty(transaction, IdentifierType.PHN, cancelDependentResponse.getPhn());
+			addAffectedParty(transaction, IdentifierType.PHN, cancelDependentResponse.getPhn(), AffectedPartyDirection.INBOUND);
 
 			return response;	
 		} catch (Exception e) {
@@ -278,74 +279,74 @@ public class GroupMemberController extends BaseController {
 
 	private Transaction auditAddGroupMemberStart(AddGroupMemberRequest addGroupMemberRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.ADD_GROUP_MEMBER);
-		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, addGroupMemberRequest.getGroupNumber());
-		addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getPhn());
+		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, addGroupMemberRequest.getGroupNumber(), AffectedPartyDirection.OUTBOUND);
+		addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
 		if (StringUtils.isNotBlank(addGroupMemberRequest.getGroupMemberNumber())) {
-			addAffectedParty(transaction, IdentifierType.GROUP_MEMBER_NUMBER, addGroupMemberRequest.getGroupMemberNumber());
+			addAffectedParty(transaction, IdentifierType.GROUP_MEMBER_NUMBER, addGroupMemberRequest.getGroupMemberNumber(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(addGroupMemberRequest.getDepartmentNumber())) {
-			addAffectedParty(transaction, IdentifierType.DEPARTMENT_NUMBER, addGroupMemberRequest.getDepartmentNumber());
+			addAffectedParty(transaction, IdentifierType.DEPARTMENT_NUMBER, addGroupMemberRequest.getDepartmentNumber(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(addGroupMemberRequest.getSpousePhn())) {
-			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getSpousePhn());
+			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getSpousePhn(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(addGroupMemberRequest.getDependentPhn1())) {
-			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn1());
+			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn1(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(addGroupMemberRequest.getDependentPhn2())) {
-			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn2());
+			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn2(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(addGroupMemberRequest.getDependentPhn3())) {
-			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn3());
+			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn3(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(addGroupMemberRequest.getDependentPhn4())) {
-			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn4());
+			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn4(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(addGroupMemberRequest.getDependentPhn5())) {
-			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn5());
+			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn5(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(addGroupMemberRequest.getDependentPhn6())) {
-			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn6());
+			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn6(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(addGroupMemberRequest.getDependentPhn7())) {
-			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn7());
+			addAffectedParty(transaction, IdentifierType.PHN, addGroupMemberRequest.getDependentPhn7(), AffectedPartyDirection.OUTBOUND);
 		}
 		return transaction;
 	}
 
 	private Transaction auditAddDependentStart(AddDependentRequest addDependentRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.ADD_DEPENDENT);
-		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, addDependentRequest.getGroupNumber());
-		addAffectedParty(transaction, IdentifierType.PHN, addDependentRequest.getPhn());
-		addAffectedParty(transaction, IdentifierType.PHN, addDependentRequest.getDependentPhn());
+		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, addDependentRequest.getGroupNumber(), AffectedPartyDirection.OUTBOUND);
+		addAffectedParty(transaction, IdentifierType.PHN, addDependentRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
+		addAffectedParty(transaction, IdentifierType.PHN, addDependentRequest.getDependentPhn(), AffectedPartyDirection.OUTBOUND);
 		return transaction;
 	}
 
 	private Transaction auditUpdateNumberAndDeptStart(UpdateNumberAndDeptRequest updateNumberAndDeptRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.UPDATE_NUMBER_AND_OR_DEPT);
-		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, updateNumberAndDeptRequest.getGroupNumber());
-		addAffectedParty(transaction, IdentifierType.PHN, updateNumberAndDeptRequest.getPhn());
+		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, updateNumberAndDeptRequest.getGroupNumber(), AffectedPartyDirection.OUTBOUND);
+		addAffectedParty(transaction, IdentifierType.PHN, updateNumberAndDeptRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
 		if (StringUtils.isNotBlank(updateNumberAndDeptRequest.getGroupMemberNumber())) {
-			addAffectedParty(transaction, IdentifierType.GROUP_MEMBER_NUMBER, updateNumberAndDeptRequest.getGroupMemberNumber());
+			addAffectedParty(transaction, IdentifierType.GROUP_MEMBER_NUMBER, updateNumberAndDeptRequest.getGroupMemberNumber(), AffectedPartyDirection.OUTBOUND);
 		}
 		if (StringUtils.isNotBlank(updateNumberAndDeptRequest.getDepartmentNumber())) {
-			addAffectedParty(transaction, IdentifierType.DEPARTMENT_NUMBER, updateNumberAndDeptRequest.getDepartmentNumber());
+			addAffectedParty(transaction, IdentifierType.DEPARTMENT_NUMBER, updateNumberAndDeptRequest.getDepartmentNumber(), AffectedPartyDirection.OUTBOUND);
 		}
 		return transaction;
 	}
 
 	private Transaction auditCancelGroupMemberStart(CancelGroupMemberRequest cancelGroupMemberRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.CANCEL_GROUP_MEMBER);
-		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, cancelGroupMemberRequest.getGroupNumber());
-		addAffectedParty(transaction, IdentifierType.PHN, cancelGroupMemberRequest.getPhn());
+		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, cancelGroupMemberRequest.getGroupNumber(), AffectedPartyDirection.OUTBOUND);
+		addAffectedParty(transaction, IdentifierType.PHN, cancelGroupMemberRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
 		return transaction;
 	}
 	
 	private Transaction auditCancelDependentStart(CancelDependentRequest cancelDependentRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.CANCEL_DEPENDENT);
-		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, cancelDependentRequest.getGroupNumber());
-		addAffectedParty(transaction, IdentifierType.PHN, cancelDependentRequest.getPhn());
-		addAffectedParty(transaction, IdentifierType.PHN, cancelDependentRequest.getDependentPhn());
+		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, cancelDependentRequest.getGroupNumber(), AffectedPartyDirection.OUTBOUND);
+		addAffectedParty(transaction, IdentifierType.PHN, cancelDependentRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
+		addAffectedParty(transaction, IdentifierType.PHN, cancelDependentRequest.getDependentPhn(), AffectedPartyDirection.OUTBOUND);
 		return transaction;
 	}
 

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/MspContractsController.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/controller/MspContractsController.java
@@ -23,6 +23,7 @@ import ca.bc.gov.hlth.hnweb.model.rest.mspcontracts.ContractInquiryRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.mspcontracts.ContractInquiryResponse;
 import ca.bc.gov.hlth.hnweb.model.rest.mspcontracts.GetContractPeriodsRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.mspcontracts.GetContractPeriodsResponse;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.persistence.entity.IdentifierType;
 import ca.bc.gov.hlth.hnweb.persistence.entity.Transaction;
 import ca.bc.gov.hlth.hnweb.security.TransactionType;
@@ -108,7 +109,7 @@ public class MspContractsController extends BaseController {
 
 	private Transaction auditGetContractPeriodsStart(GetContractPeriodsRequest getContractPeriodsRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.GET_CONTRACT_PERIODS);
-		addAffectedParty(transaction, IdentifierType.PHN, getContractPeriodsRequest.getPhn());
+		addAffectedParty(transaction, IdentifierType.PHN, getContractPeriodsRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
 		return transaction;
 	}
 
@@ -117,20 +118,20 @@ public class MspContractsController extends BaseController {
 		List<String> auditedGroupNumbers = new ArrayList<>();
 
 		transactionComplete(transaction);		
-		addAffectedParty(transaction, IdentifierType.PHN, getContractPeriodsResponse.getPhn());
+		addAffectedParty(transaction, IdentifierType.PHN, getContractPeriodsResponse.getPhn(), AffectedPartyDirection.INBOUND);
 		auditedPhns.add(getContractPeriodsResponse.getPhn());
 		
 		getContractPeriodsResponse.getBeneficiaryContractPeriods().forEach(bcp -> {
 			if (!auditedPhns.contains(bcp.getPhn())) {
-				addAffectedParty(transaction, IdentifierType.PHN, bcp.getPhn());				
+				addAffectedParty(transaction, IdentifierType.PHN, bcp.getPhn(), AffectedPartyDirection.INBOUND);				
 				auditedPhns.add(bcp.getPhn());
 			}
 			if(!auditedGroupNumbers.contains(bcp.getGroupNumber())) {
-				addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, bcp.getGroupNumber());
+				addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, bcp.getGroupNumber(), AffectedPartyDirection.INBOUND);
 				auditedGroupNumbers.add(bcp.getGroupNumber());
 			}
 			if(!auditedPhns.contains(bcp.getContractHolder())) {
-				addAffectedParty(transaction, IdentifierType.PHN, bcp.getContractHolder());
+				addAffectedParty(transaction, IdentifierType.PHN, bcp.getContractHolder(), AffectedPartyDirection.INBOUND);
 				auditedPhns.add(bcp.getContractHolder());
 			}
 		});
@@ -138,8 +139,8 @@ public class MspContractsController extends BaseController {
 	
 	private Transaction auditContractInquiryStart(ContractInquiryRequest contractInquiryRequest, HttpServletRequest request) {
 		Transaction transaction = transactionStart(request, TransactionType.CONTRACT_INQUIRY);
-		addAffectedParty(transaction, IdentifierType.PHN, contractInquiryRequest.getPhn());
-		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, contractInquiryRequest.getGroupNumber());
+		addAffectedParty(transaction, IdentifierType.PHN, contractInquiryRequest.getPhn(), AffectedPartyDirection.OUTBOUND);
+		addAffectedParty(transaction, IdentifierType.GROUP_NUMBER, contractInquiryRequest.getGroupNumber(), AffectedPartyDirection.OUTBOUND);
 		return transaction;
 	}
 
@@ -147,12 +148,12 @@ public class MspContractsController extends BaseController {
 		List<String> auditedPhns = new ArrayList<>();
 
 		transactionComplete(transaction);		
-		addAffectedParty(transaction, IdentifierType.PHN, contractInquiryResponse.getPhn());
+		addAffectedParty(transaction, IdentifierType.PHN, contractInquiryResponse.getPhn(), AffectedPartyDirection.INBOUND);
 		auditedPhns.add(contractInquiryResponse.getPhn());
 		
 		contractInquiryResponse.getContractInquiryBeneficiaries().forEach(cib -> {
 			if (!auditedPhns.contains(cib.getPhn())) {
-				addAffectedParty(transaction, IdentifierType.PHN, cib.getPhn());				
+				addAffectedParty(transaction, IdentifierType.PHN, cib.getPhn(), AffectedPartyDirection.INBOUND);				
 				auditedPhns.add(cib.getPhn());
 			}			
 		});

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/persistence/entity/AffectedParty.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/persistence/entity/AffectedParty.java
@@ -101,6 +101,7 @@ public class AffectedParty {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + (int) (affectedPartyId ^ (affectedPartyId >>> 32));
+		result = prime * result + ((direction == null) ? 0 : direction.hashCode());
 		result = prime * result + ((identifier == null) ? 0 : identifier.hashCode());
 		result = prime * result + ((identifierType == null) ? 0 : identifierType.hashCode());
 		result = prime * result + ((transaction == null) ? 0 : transaction.hashCode());
@@ -117,6 +118,11 @@ public class AffectedParty {
 			return false;
 		AffectedParty other = (AffectedParty) obj;
 		if (affectedPartyId != other.affectedPartyId)
+			return false;
+		if (direction == null) {
+			if (other.direction != null)
+				return false;
+		} else if (!direction.equals(other.direction))
 			return false;
 		if (identifier == null) {
 			if (other.identifier != null)
@@ -138,8 +144,8 @@ public class AffectedParty {
 
 	@Override
 	public String toString() {
-		return "AffectedParty [affectedPartyId=" + affectedPartyId + ", identifier=" + identifier + ", identifierType=" + identifierType
-				+ ", transaction=" + transaction + "]";
+		return "AffectedParty [affectedPartyId=" + affectedPartyId + ", identifier=" + identifier + ", identifierType="
+				+ identifierType + ", direction=" + direction + ", transaction=" + transaction + "]";
 	}
 
 }

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/persistence/entity/AffectedParty.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/persistence/entity/AffectedParty.java
@@ -40,6 +40,13 @@ public class AffectedParty {
 	private String identifierType;
 
 	/**
+	 * Specifies the direction of the the identifier in the transaction. (Inbound, Outbound)
+	 */
+	@Basic
+	@Column(name = "direction", nullable = false)
+	private String direction;
+
+	/**
 	 * Foreign key to the transaction the party is the subject of.
 	 */
 	@ManyToOne
@@ -71,6 +78,14 @@ public class AffectedParty {
 
 	public void setIdentifierType(String identifierType) {
 		this.identifierType = identifierType;
+	}
+
+	public String getDirection() {
+		return direction;
+	}
+
+	public void setDirection(String direction) {
+		this.direction = direction;
 	}
 
 	public Transaction getTransaction() {

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/persistence/entity/AffectedPartyDirection.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/persistence/entity/AffectedPartyDirection.java
@@ -1,0 +1,18 @@
+package ca.bc.gov.hlth.hnweb.persistence.entity;
+
+public enum AffectedPartyDirection {
+
+	INBOUND("Inbound"),
+	OUTBOUND("Outbound");
+
+	private String value;
+
+	private AffectedPartyDirection(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+}

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/AuditService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/AuditService.java
@@ -168,7 +168,7 @@ public class AuditService {
 		AffectedParty affectedParty = new AffectedParty();
 		affectedParty.setIdentifier(identifier);
 		affectedParty.setIdentifierType(identifierType.getValue());
-		affectedParty.setDirection(direction.name());
+		affectedParty.setDirection(direction.getValue());
 		affectedParty.setTransaction(transaction);
 		return affectedPartyRepository.save(affectedParty);
 	}

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/AuditService.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/service/AuditService.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedParty;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.persistence.entity.ErrorLevel;
 import ca.bc.gov.hlth.hnweb.persistence.entity.EventMessage;
 import ca.bc.gov.hlth.hnweb.persistence.entity.IdentifierType;
@@ -150,9 +151,10 @@ public class AuditService {
 	 * 
 	 * @param transaction The associated Transaction
 	 * @param phn The phn of the affected party
+	 * @param direction The value to indicate if the party is affected when the transaction is being sent or being received.
 	 */
-	public AffectedParty createAffectedParty(Transaction transaction, String phn) {
-		return createAffectedParty(transaction, IdentifierType.PHN, phn);
+	public AffectedParty createAffectedParty(Transaction transaction, String phn, AffectedPartyDirection direction) {
+		return createAffectedParty(transaction, IdentifierType.PHN, phn, direction);
 	}
 	
 	/**
@@ -162,10 +164,11 @@ public class AuditService {
 	 * @param identifierType The type of identifier
 	 * @param identifier The value of the identifier
 	 */
-	public AffectedParty createAffectedParty(Transaction transaction, IdentifierType identifierType, String identifier) {
+	public AffectedParty createAffectedParty(Transaction transaction, IdentifierType identifierType, String identifier, AffectedPartyDirection direction) {
 		AffectedParty affectedParty = new AffectedParty();
 		affectedParty.setIdentifier(identifier);
 		affectedParty.setIdentifierType(identifierType.getValue());
+		affectedParty.setDirection(direction.name());
 		affectedParty.setTransaction(transaction);
 		return affectedPartyRepository.save(affectedParty);
 	}

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/BaseControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/BaseControllerTest.java
@@ -69,7 +69,7 @@ public class BaseControllerTest {
 	}
 	
 	/**
-	 * Asserts the the Transaction is created.
+	 * Asserts the Transaction is created.
 	 * 
 	 * @param type The type of transaction.
 	 * @return The Transaction to perform further assertions on.
@@ -83,11 +83,13 @@ public class BaseControllerTest {
 	}
 	
 	/**
-	 * Asserts the the Transaction is created.
+	 * Asserts correct number of AffectedParty entries has been created.
 	 * @param count 
 	 * 
-	 * @param type The type of transaction.
-	 * @return The Transaction to perform further assertions on.
+	 * @param direction the direction of the AffectedParty being logged.
+	 * @count the expected number of AffectedPartys
+	 * 
+	 * @return The number of AffectedPartys found for the specified direction.
 	 */
 	protected int assertAffectedParyCount(AffectedPartyDirection direction, int count) {
 		AffectedParty example = new AffectedParty();

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/BaseControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/BaseControllerTest.java
@@ -1,8 +1,10 @@
 package ca.bc.gov.hlth.hnweb;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,10 +15,14 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Example;
+import org.springframework.data.domain.ExampleMatcher;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.transaction.annotation.Transactional;
 
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedParty;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.persistence.entity.Transaction;
+import ca.bc.gov.hlth.hnweb.persistence.repository.AffectedPartyRepository;
 import ca.bc.gov.hlth.hnweb.persistence.repository.TransactionRepository;
 import ca.bc.gov.hlth.hnweb.security.SecurityUtil;
 import ca.bc.gov.hlth.hnweb.security.TransactionType;
@@ -33,6 +39,9 @@ public class BaseControllerTest {
 	
 	@Autowired
 	private TransactionRepository transactionRepository;
+	
+	@Autowired
+	private AffectedPartyRepository affectedPartyRepository;
 	
 	protected static MockWebServer mockBackEnd;
 	
@@ -71,6 +80,24 @@ public class BaseControllerTest {
 		Optional<Transaction> opt = transactionRepository.findOne(Example.of(example));
 		assertTrue(opt.isPresent());
 		return opt.get();
+	}
+	
+	/**
+	 * Asserts the the Transaction is created.
+	 * @param count 
+	 * 
+	 * @param type The type of transaction.
+	 * @return The Transaction to perform further assertions on.
+	 */
+	protected int assertAffectedParyCount(AffectedPartyDirection direction, int count) {
+		AffectedParty example = new AffectedParty();
+		example.setAffectedPartyId(0);
+		example.setDirection(direction.getValue());
+		ExampleMatcher matcher = ExampleMatcher.matching()
+				.withIgnorePaths("affectedPartyId"); // Remove affectedPartyId as its value would default to 0 because it's of type long so would not be ignored as null in the default matchingAll() matcher
+		List<AffectedParty> affectedParties = affectedPartyRepository.findAll(Example.of(example, matcher));
+		assertEquals(count, affectedParties.size());
+		return affectedParties.size();
 	}
 	
 }

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/EligibilityControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/EligibilityControllerTest.java
@@ -31,6 +31,7 @@ import ca.bc.gov.hlth.hnweb.model.rest.eligibility.LookupPhnBeneficiary;
 import ca.bc.gov.hlth.hnweb.model.rest.eligibility.LookupPhnRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.eligibility.LookupPhnResponse;
 import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedParty;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.persistence.entity.IdentifierType;
 import ca.bc.gov.hlth.hnweb.persistence.entity.Transaction;
 import ca.bc.gov.hlth.hnweb.persistence.entity.TransactionEvent;
@@ -159,6 +160,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.CHECK_ELIGIBILITY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
 	@Test
@@ -190,6 +193,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
       
         assertTransactionCreated(TransactionType.CHECK_ELIGIBILITY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 
 	@Test
@@ -221,6 +226,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.CHECK_ELIGIBILITY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 
 	@Test
@@ -260,6 +267,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));		
         
         assertTransactionCreated(TransactionType.MSP_COVERAGE_STATUS_CHECK);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
 	@Test
@@ -300,6 +309,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.MSP_COVERAGE_STATUS_CHECK);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
 	@Test
@@ -338,6 +349,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.MSP_COVERAGE_STATUS_CHECK);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
 	@Test
@@ -376,6 +389,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));	
         
         assertTransactionCreated(TransactionType.MSP_COVERAGE_STATUS_CHECK);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
 	@Test
@@ -414,6 +429,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.PHN_INQUIRY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
 	@Test
@@ -442,6 +459,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.PHN_INQUIRY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 0);
 	}
 	
 	@Test
@@ -470,6 +489,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.PHN_INQUIRY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 0);
 	}
 	
 	@Test
@@ -510,6 +531,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.PHN_INQUIRY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
 	
@@ -554,6 +577,9 @@ public class EligibilityControllerTest extends BaseControllerTest {
 		// - 1 x Response AffectedParty
 
         Transaction transaction = assertTransactionCreated(TransactionType.PHN_LOOKUP);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
+        
 		assertEquals("00000010", transaction.getOrganization());
 		assertNotNull(transaction.getServer());
 		assertNotNull(transaction.getSessionId());
@@ -601,18 +627,21 @@ public class EligibilityControllerTest extends BaseControllerTest {
 		assertNotNull(contractNumber.getAffectedPartyId());
 		assertEquals("123456789", contractNumber.getIdentifier());
 		assertEquals(IdentifierType.CONTRACT_NUMBER.getValue(), contractNumber.getIdentifierType());
+		assertEquals(AffectedPartyDirection.OUTBOUND.getValue(), contractNumber.getDirection());
 		assertEquals(transaction, contractNumber.getTransaction());		
 		
 		AffectedParty groupNumber = affectedParties.get(1);
 		assertNotNull(groupNumber.getAffectedPartyId());
 		assertEquals("1234567", groupNumber.getIdentifier());
 		assertEquals(IdentifierType.GROUP_NUMBER.getValue(), groupNumber.getIdentifierType());
+		assertEquals(AffectedPartyDirection.OUTBOUND.getValue(), groupNumber.getDirection());
 		assertEquals(transaction, groupNumber.getTransaction());
 		
 		AffectedParty phn = affectedParties.get(2);
 		assertNotNull(phn.getAffectedPartyId());
 		assertEquals("9123456789", phn.getIdentifier());
 		assertEquals(IdentifierType.PHN.getValue(), phn.getIdentifierType());
+		assertEquals(AffectedPartyDirection.INBOUND.getValue(), phn.getDirection());
 		assertEquals(transaction, phn.getTransaction());
 	}
 
@@ -648,6 +677,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals("M", beneficiary.getGender());
         
         assertTransactionCreated(TransactionType.PHN_LOOKUP);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 50);
 	}
 	
 	@Test
@@ -673,6 +704,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(0, beneficiaries.size());
         
         assertTransactionCreated(TransactionType.PHN_LOOKUP);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 0);
 	}
 	
 	@Test
@@ -698,6 +731,8 @@ public class EligibilityControllerTest extends BaseControllerTest {
         assertEquals(0, beneficiaries.size());
         
         assertTransactionCreated(TransactionType.PHN_LOOKUP);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 0);
 	}
 
     /**

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/EnrollmentControllerTest.java
@@ -22,6 +22,7 @@ import ca.bc.gov.hlth.hnweb.model.rest.enrollment.GetPersonDetailsRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.enrollment.GetPersonDetailsResponse;
 import ca.bc.gov.hlth.hnweb.model.rest.enrollment.NameSearchRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.enrollment.NameSearchResponse;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.security.TransactionType;
 import ca.bc.gov.hlth.hnweb.utils.TestUtil;
 import okhttp3.mockwebserver.MockResponse;
@@ -78,6 +79,8 @@ public class EnrollmentControllerTest extends BaseControllerTest {
         assertEquals("/", recordedRequest.getPath());
         
         assertTransactionCreated(TransactionType.ENROLL_SUBSCRIBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 0);
     }
     
     @Test
@@ -101,6 +104,8 @@ public class EnrollmentControllerTest extends BaseControllerTest {
         assertEquals("/", recordedRequest.getPath());
         
         assertTransactionCreated(TransactionType.ENROLL_SUBSCRIBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 0);
     }
     
     @Test
@@ -127,6 +132,8 @@ public class EnrollmentControllerTest extends BaseControllerTest {
         assertEquals("/", recordedRequest.getPath());       
         
         assertTransactionCreated(TransactionType.ENROLL_SUBSCRIBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 0);
     }
     
     @Test
@@ -152,6 +159,8 @@ public class EnrollmentControllerTest extends BaseControllerTest {
         assertEquals("/", recordedRequest.getPath());       
         
         assertTransactionCreated(TransactionType.ENROLL_SUBSCRIBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     
@@ -178,6 +187,8 @@ public class EnrollmentControllerTest extends BaseControllerTest {
         assertEquals("/", recordedRequest.getPath());
         
         assertTransactionCreated(TransactionType.GET_PERSON_DETAILS);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -203,6 +214,8 @@ public class EnrollmentControllerTest extends BaseControllerTest {
         assertEquals("/", recordedRequest.getPath());
         
         assertTransactionCreated(TransactionType.GET_PERSON_DETAILS);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -232,6 +245,8 @@ public class EnrollmentControllerTest extends BaseControllerTest {
         assertEquals("/", recordedRequest.getPath());
         
         assertTransactionCreated(TransactionType.NAME_SEARCH);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 0);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 3);
     }
     
     
@@ -259,6 +274,8 @@ public class EnrollmentControllerTest extends BaseControllerTest {
         assertEquals("/", recordedRequest.getPath());
         
         assertTransactionCreated(TransactionType.NAME_SEARCH);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 0);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 0);
     }
     
     /**

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/GroupMemberControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/GroupMemberControllerTest.java
@@ -29,6 +29,7 @@ import ca.bc.gov.hlth.hnweb.model.rest.groupmember.CancelGroupMemberResponse;
 import ca.bc.gov.hlth.hnweb.model.rest.groupmember.MemberAddress;
 import ca.bc.gov.hlth.hnweb.model.rest.groupmember.UpdateNumberAndDeptRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.groupmember.UpdateNumberAndDeptResponse;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.security.TransactionType;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -78,6 +79,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
     	assertEquals("Department Number or Group Number is required", exception.getReason());
     	
         assertTransactionCreated(TransactionType.UPDATE_NUMBER_AND_OR_DEPT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 0);
     }
 
     @Test
@@ -107,6 +110,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.UPDATE_NUMBER_AND_OR_DEPT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 4);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -136,6 +141,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.UPDATE_NUMBER_AND_OR_DEPT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 4);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -162,6 +169,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_GROUP_MEMBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -189,6 +198,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_GROUP_MEMBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -216,6 +227,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_GROUP_MEMBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
 
     @Test
@@ -242,6 +255,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_GROUP_MEMBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -268,6 +283,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_GROUP_MEMBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -294,6 +311,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_GROUP_MEMBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -327,6 +346,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.ADD_GROUP_MEMBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 4);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -360,6 +381,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.ADD_GROUP_MEMBER);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 4);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -387,6 +410,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.ADD_DEPENDENT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 3);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
 
     @Test
@@ -414,6 +439,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.ADD_DEPENDENT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 3);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
 
     @Test
@@ -442,6 +469,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
 	    assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.ADD_DEPENDENT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 3);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
     
     @Test
@@ -469,6 +498,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
 	    assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.ADD_DEPENDENT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 3);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
     @Test
@@ -496,6 +527,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_DEPENDENT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 3);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -523,6 +556,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_DEPENDENT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 3);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -550,6 +585,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_DEPENDENT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 3);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
     
     @Test
@@ -577,6 +614,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_DEPENDENT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 3);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
 
     @Test
@@ -604,6 +643,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_DEPENDENT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 3);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
 
     @Test
@@ -632,6 +673,8 @@ public class GroupMemberControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
 
         assertTransactionCreated(TransactionType.CANCEL_DEPENDENT);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 3);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
     }
    
     /**

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/MspContractsControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/controller/MspContractsControllerTest.java
@@ -22,6 +22,7 @@ import ca.bc.gov.hlth.hnweb.model.rest.mspcontracts.ContractInquiryRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.mspcontracts.ContractInquiryResponse;
 import ca.bc.gov.hlth.hnweb.model.rest.mspcontracts.GetContractPeriodsRequest;
 import ca.bc.gov.hlth.hnweb.model.rest.mspcontracts.GetContractPeriodsResponse;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.security.TransactionType;
 import ca.bc.gov.hlth.hnweb.util.V2MessageUtil;
 import okhttp3.mockwebserver.MockResponse;
@@ -141,6 +142,8 @@ public class MspContractsControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.GET_CONTRACT_PERIODS);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 4);
 	}
 	
 	@Test
@@ -184,6 +187,8 @@ public class MspContractsControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));        
         
         assertTransactionCreated(TransactionType.GET_CONTRACT_PERIODS);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 22);
 	}
 	
 	@Test
@@ -214,6 +219,8 @@ public class MspContractsControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.GET_CONTRACT_PERIODS);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 1);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
 	@Test
@@ -271,6 +278,8 @@ public class MspContractsControllerTest extends BaseControllerTest {
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         
         assertTransactionCreated(TransactionType.CONTRACT_INQUIRY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 2);
 	}
 	
 	@Test
@@ -301,6 +310,8 @@ public class MspContractsControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE));
         assertTransactionCreated(TransactionType.CONTRACT_INQUIRY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
 	@Test
@@ -330,6 +341,8 @@ public class MspContractsControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE)); 
         assertTransactionCreated(TransactionType.CONTRACT_INQUIRY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 1);
 	}
 	
 	@Test
@@ -373,6 +386,8 @@ public class MspContractsControllerTest extends BaseControllerTest {
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
         assertEquals(MediaType.TEXT_PLAIN.toString(), recordedRequest.getHeader(CONTENT_TYPE)); 
         assertTransactionCreated(TransactionType.CONTRACT_INQUIRY);
+        assertAffectedParyCount(AffectedPartyDirection.OUTBOUND, 2);
+        assertAffectedParyCount(AffectedPartyDirection.INBOUND, 20);
 	}
 	
     /**

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/service/AuditServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/service/AuditServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpStatus;
 import ca.bc.gov.hlth.hnweb.exception.ExceptionType;
 import ca.bc.gov.hlth.hnweb.exception.HNWebException;
 import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedParty;
+import ca.bc.gov.hlth.hnweb.persistence.entity.AffectedPartyDirection;
 import ca.bc.gov.hlth.hnweb.persistence.entity.ErrorLevel;
 import ca.bc.gov.hlth.hnweb.persistence.entity.EventMessage;
 import ca.bc.gov.hlth.hnweb.persistence.entity.IdentifierType;
@@ -105,7 +106,7 @@ public class AuditServiceTest {
 	@Test
 	public void testCreateAffectedParty() {
 		Transaction transaction = auditService.createTransaction("0:0:0:0:0:0:0:1", TransactionType.CHECK_ELIGIBILITY);
-		AffectedParty newAffectedParty = auditService.createAffectedParty(transaction, IdentifierType.GROUP_NUMBER, "6337109");
+		AffectedParty newAffectedParty = auditService.createAffectedParty(transaction, IdentifierType.GROUP_NUMBER, "6337109", AffectedPartyDirection.OUTBOUND);
 		
 		Optional<AffectedParty> optional = affectedPartyRepository.findById(newAffectedParty.getAffectedPartyId());
 		assertTrue(optional.isPresent());

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/service/AuditServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/service/AuditServiceTest.java
@@ -57,13 +57,13 @@ public class AuditServiceTest {
 	private static MockedStatic<SecurityUtil> mockStatic;
 	
 	@BeforeAll
-    static void setUp() throws IOException {
+    static void setUp() {
         mockStatic = Mockito.mockStatic(SecurityUtil.class);
         mockStatic.when(SecurityUtil::loadUserInfo).thenReturn(new UserInfo("unittest", "00000010", "hnweb-user", UUID.randomUUID().toString()));
     }
 	
     @AfterAll
-    static void tearDown() throws IOException {
+    static void tearDown() {
         mockStatic.close();
     }
 	
@@ -115,6 +115,7 @@ public class AuditServiceTest {
 		assertNotNull(affectedParty.getAffectedPartyId());
 		assertEquals("6337109", affectedParty.getIdentifier());
 		assertEquals(IdentifierType.GROUP_NUMBER.getValue(), affectedParty.getIdentifierType());
+		assertEquals(AffectedPartyDirection.OUTBOUND, affectedParty.getDirection());
 		assertEquals(transaction, affectedParty.getTransaction());
 	}
 	


### PR DESCRIPTION
Updated auditing on all transactions to include a value for the new column 'direction' on AffectedParty.