### PR TITLE
Made keycloak client configurable using the Spring security audience value

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/security/SecurityUtil.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/security/SecurityUtil.java
@@ -7,9 +7,11 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * Utility class for working with authentication, tokens.
  */
+@Component
 public class SecurityUtil {
 	private static final Logger logger = LoggerFactory.getLogger(SecurityUtil.class);
 
@@ -27,10 +30,10 @@ public class SecurityUtil {
 	
 	private static final String ORGANIZATION_ID = "id";
 	
-	private static final String KEYCLOAK_CLIENT = "MSPDIRECT-SERVICE";
-	
 	private static final String USER_ROLES = "roles";
 
+    private static String KEYCLOAK_CLIENT;
+    
 	public static UserInfo loadUserInfo() {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 		Jwt jwt = (Jwt)auth.getPrincipal();
@@ -92,4 +95,7 @@ public class SecurityUtil {
         return permissions;
 	}
 
-}
+    @Value("${spring.security.oauth2.resourceserver.jwt.audience}")
+    public void setKeycloakClientStatic(String keycloakClient){
+        SecurityUtil.KEYCLOAK_CLIENT = keycloakClient;
+    }}

--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/security/SecurityUtil.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/security/SecurityUtil.java
@@ -34,7 +34,12 @@ public class SecurityUtil {
 
     private static String KEYCLOAK_CLIENT;
     
-	public static UserInfo loadUserInfo() {
+    @Value("${spring.security.oauth2.resourceserver.jwt.audience}")
+    private void setKeycloakClientStatic(String keycloakClient){
+        SecurityUtil.KEYCLOAK_CLIENT = keycloakClient;
+    }
+
+    public static UserInfo loadUserInfo() {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 		Jwt jwt = (Jwt)auth.getPrincipal();
 		
@@ -95,7 +100,4 @@ public class SecurityUtil {
         return permissions;
 	}
 
-    @Value("${spring.security.oauth2.resourceserver.jwt.audience}")
-    public void setKeycloakClientStatic(String keycloakClient){
-        SecurityUtil.KEYCLOAK_CLIENT = keycloakClient;
-    }}
+}


### PR DESCRIPTION
Updated the SecurityUtil to allow the value of the Keycloak client to be configurable in properties. Currently uses the Spring security audience value as they are expected to be the same. Also, this value has to injected to a static variable as it's used in static methods so uses method injection instead of directly on the variable.