### PR TITLE
6787 api unavailable error handling

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -21,12 +21,11 @@ import { createRouter } from './router'
 import UserService from './services/UserService'
 import { useAuthStore } from './stores/auth'
 
-// import store from './store'
-
 keycloak.onReady = async function (authenticated) {
   // Only initialize the application after keycloak is ready
   // otherwise the router won't have the correct authentication
   // info to work with
+  let apiAvailable = true
   let permissions = []
   try {
     if (authenticated) {
@@ -34,15 +33,14 @@ keycloak.onReady = async function (authenticated) {
       permissions = data
     }
   } catch (err) {
-    /* The error will only be thrown from the API when no role is found and in that case an appropriate unauthorized page will be shown,
-     so it does not need to be handled or displayed here.
-     */
+    // An error here indicates that MSP Direct API is unavailable
+    apiAvailable = false
   } finally {
-    initApp(permissions)
+    initApp(permissions, apiAvailable)
   }
 }
 
-function initApp(permissions) {
+function initApp(permissions, apiAvailable) {
   const app = createApp(App)
 
   app.component('AppCol', AppCol)
@@ -58,6 +56,7 @@ function initApp(permissions) {
   app.use(createPinia())
   const auth = useAuthStore()
   auth.permissions = permissions
+  auth.apiAvailable = apiAvailable
 
   const router = createRouter(app)
   app.use(router)

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter as createVueRouter, createWebHistory } from 'vue-router'
 
+import Error from './../views/Error.vue'
 import Help from './../views/Help.vue'
 import Home from './../views/Home.vue'
 import CheckEligibility from './../views/eligibility/CheckEligibility.vue'
@@ -246,6 +247,14 @@ const createRoutes = (app) => [
     ],
   },
   {
+    path: '/error',
+    name: 'Error',
+    component: Error,
+    meta: {
+      requiresAuth: false,
+    },
+  },
+  {
     path: '/help',
     name: 'Help',
     component: Help,
@@ -298,6 +307,14 @@ export const createRouter = (app) => {
 
     const authenticated = app.config.globalProperties.$keycloak.authenticated
 
+    // Check if the backend is available
+    if (!authStore.apiAvailable && to.name !== 'Error') {
+      console.log(`To ${to.name}`)
+      alertStore.setErrorAlert('MSP Direct API is unavailable.')
+      next({ name: 'Error' })
+      return
+    }
+
     // Authenticated users should never see the Login screen
     // Send them to Home instead
     if (authenticated && to.name === 'Login') {
@@ -320,7 +337,7 @@ export const createRouter = (app) => {
 
     // Validate that the user has permissions
     const hasAnyPermission = authStore.hasAnyPermission
-    if (!hasAnyPermission && to.name !== 'Unauthorized') {
+    if (!hasAnyPermission && to.name !== 'Unauthorized' && to.name !== 'Help') {
       next({ name: 'Unauthorized' })
       return
     }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -307,9 +307,8 @@ export const createRouter = (app) => {
 
     const authenticated = app.config.globalProperties.$keycloak.authenticated
 
-    // Check if the backend is available
-    if (!authStore.apiAvailable && to.name !== 'Error') {
-      console.log(`To ${to.name}`)
+    // Check if the API is available
+    if (!authStore.apiAvailable && to.name !== 'Error' && to.name !== 'Help') {
       alertStore.setErrorAlert('MSP Direct API is unavailable.')
       next({ name: 'Error' })
       return

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 export const useAuthStore = defineStore('auth', {
   state: () => ({
     permissions: [],
+    apiAvailable: null,
   }),
   getters: {
     hasPermission: (state) => {

--- a/frontend/src/views/Error.vue
+++ b/frontend/src/views/Error.vue
@@ -1,6 +1,22 @@
 <template>
-  <h1>Error</h1>
+  <h1>System Error</h1>
   <div>
     <p>An error has occurred with MSP Direct. Please contact application support at <a href="mailto:HLTH.HnetConnection@gov.bc.ca?subject=MSP Direct Error">HLTH.HnetConnection@gov.bc.ca</a></p>
+    <p>Additional contact info is available on the <router-link @click="resetAlert()" :to="{ name: 'Help' }">Help</router-link> screen.</p>
   </div>
 </template>
+<script>
+import { useAlertStore } from '../stores/alert'
+
+export default {
+  name: 'Error',
+  setup() {
+    return { alertStore: useAlertStore() }
+  },
+  methods: {
+    resetAlert() {
+      this.alertStore.dismissAlert()
+    },
+  },
+}
+</script>

--- a/frontend/src/views/Error.vue
+++ b/frontend/src/views/Error.vue
@@ -1,0 +1,6 @@
+<template>
+  <h1>Error</h1>
+  <div>
+    <p>An error has occurred with MSP Direct. Please contact application support at <a href="mailto:HLTH.HnetConnection@gov.bc.ca?subject=MSP Direct Error">HLTH.HnetConnection@gov.bc.ca</a></p>
+  </div>
+</template>


### PR DESCRIPTION
Added handling for when the API is unavailable (which is detected when attempting to load the permissions for an authenticated user). User gets taken to a generic error page with a specific error message about the API being unavailable. Also enabled Help access in this situation which wasn't working initially because the user doesn't have permissions.