### PR TITLE
6913 update role permission config

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/security/SecurityUtil.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/security/SecurityUtil.java
@@ -88,7 +88,7 @@ public class SecurityUtil {
         List<String> roles = loadRoles(jwt);
         List<String> permissions = new ArrayList<>();
         roles.forEach(role -> {
-        	List<String> currentPermissions = rolePermissions.get(role);
+        	List<String> currentPermissions = rolePermissions.get(role.toLowerCase());
         	if (currentPermissions != null) {
         		permissions.addAll(currentPermissions);	
         	} else {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -29,37 +29,3 @@ v2:
     sendingFacility: HN-WEB
     receivingFacility: BC00001013
     processingID: D
-
-# Mapping of roles (SPGs) to specific permissions
-security:
-  rolePermissions:
-    DUMMY:
-      - Dummy
-    E45:
-      - MSPCoverageCheck
-    ELIGIBILITY:
-      - MSPCoverageCheck
-      - CheckEligibility
-      - PHNInquiry
-    TRAININGHEALTHAUTH:
-      - MSPCoverageCheck
-      - CheckEligibility
-      - AddGroupMember
-      - AddDependent
-      - GetContractPeriods
-      - UpdateNumberAndDept
-      - CancelGroupMember
-      - CancelDependent
-      - GetContractAddress
-      - UpdateContractAddress
-      - ContractInquiry
-      - PHNInquiry
-      - PHNLookup
-      - ReinstateOverAgeDependent
-      - ReinstateCancelledCoverage
-      - RenewCancelledCoverage
-      - ChangeEffectiveDate
-      - ChangeCancelDate
-      - ExtendCancelDate
-      - AddPermitHolderWOPHN
-      - AddPermitHolderWithPHN

--- a/backend/src/test/java/ca/bc/gov/hlth/hnweb/security/SecurityPropertiesTest.java
+++ b/backend/src/test/java/ca/bc/gov/hlth/hnweb/security/SecurityPropertiesTest.java
@@ -20,7 +20,7 @@ public class SecurityPropertiesTest {
 		Map<String, List<String>> rolePermissions = securityProperties.getRolePermissions();
 		assertEquals(4, rolePermissions.size());
 		
-		List<String> e45Permissions = rolePermissions.get("E45");
+		List<String> e45Permissions = rolePermissions.get("e45");
 		assertEquals(1, e45Permissions.size());
 		assertEquals("MSPCoverageCheck", e45Permissions.get(0));
 	}

--- a/backend/src/test/resources/application-dev.yaml
+++ b/backend/src/test/resources/application-dev.yaml
@@ -76,3 +76,37 @@ hibc:
   cert:
     file: classpath:keystore/testcert.pfx
     password: abc123
+
+ # Mapping of roles (SPGs) to specific permissions
+security:
+  rolePermissions:
+    dummy:
+      - Dummy
+    e45:
+      - MSPCoverageCheck
+    eligibility:
+      - MSPCoverageCheck
+      - CheckEligibility
+      - PHNInquiry
+    traininghealthauth:
+      - MSPCoverageCheck
+      - CheckEligibility
+      - AddGroupMember
+      - AddDependent
+      - GetContractPeriods
+      - UpdateNumberAndDept
+      - CancelGroupMember
+      - CancelDependent
+      - GetContractAddress
+      - UpdateContractAddress
+      - ContractInquiry
+      - PHNInquiry
+      - PHNLookup
+      - ReinstateOverAgeDependent
+      - ReinstateCancelledCoverage
+      - RenewCancelledCoverage
+      - ChangeEffectiveDate
+      - ChangeCancelDate
+      - ExtendCancelDate
+      - AddPermitHolderWOPHN
+      - AddPermitHolderWithPHN


### PR DESCRIPTION
Moved role/permission configuration from application.yaml to application-dev.yaml (development) or env variables (OpenShift).
Because of the way maps are created via env variables the roles need to be converted to lower case.
Updated unit tests to reflect updates.