### PR TITLE
8418 r50c masked name also hides other attributes

### DIFF
--- a/backend/src/main/java/ca/bc/gov/hlth/hnweb/converter/hl7v3/GetDemographicsConverter.java
+++ b/backend/src/main/java/ca/bc/gov/hlth/hnweb/converter/hl7v3/GetDemographicsConverter.java
@@ -101,28 +101,23 @@ public class GetDemographicsConverter {
 			GetPersonDetailsResponse personDetailsResponse) {
 		Person person = demographicsResponse.getPerson();
 		// "Documented" should always be shown over a "Declared" name.
-		Name name = person.getDocumentedName();
-		if (name == null) {
-			name = person.getDeclaredName();
-		}
-
+		Name name = person.getDocumentedName() != null ? person.getDocumentedName() : person.getDeclaredName();
 		if (name != null) {
-			personDetailsResponse.setPhn(person.getPhn());
 			personDetailsResponse.setGivenName(name.getFirstGivenName());
 			personDetailsResponse.setSecondName(name.getSecondGivenName());
 			personDetailsResponse.setSurname(name.getSurname());
-
-			if (person.getBirthDate() != null) {
-				String birthDate = V3MessageUtil.convertDateToString(person.getBirthDate());
-				personDetailsResponse.setDateOfBirth(birthDate);
-			}
-			
-			String deathDate = person.getDeathDate() != null ? V3MessageUtil.convertDateToString(person.getDeathDate()) :"N/A";			
-			personDetailsResponse.setDateOfDeath(deathDate);
-			
-			personDetailsResponse.setGender(person.getGender());
 		}
-		
+
+		if (person.getBirthDate() != null) {
+			String birthDate = V3MessageUtil.convertDateToString(person.getBirthDate());
+			personDetailsResponse.setDateOfBirth(birthDate);
+		}
+
+		personDetailsResponse.setPhn(person.getPhn());
+		String deathDate = person.getDeathDate() != null ? V3MessageUtil.convertDateToString(person.getDeathDate()): "N/A";
+		personDetailsResponse.setDateOfDeath(deathDate);
+		personDetailsResponse.setGender(person.getGender());
+
 		Address physicalAddress = demographicsResponse.getPerson().getPhysicalAddress();
 		if (physicalAddress != null) {
 			personDetailsResponse.setAddress1(physicalAddress.getAddressLine1());

--- a/frontend/tests/e2e/tests/enrollment/AddVisaResidentWithPHNTest.js
+++ b/frontend/tests/e2e/tests/enrollment/AddVisaResidentWithPHNTest.js
@@ -1,10 +1,9 @@
-import dayjs from 'dayjs'
-
-import { OUTPUT_DATE_FORMAT } from '../../../../src/util/constants'
-import { SITE_UNDER_TEST } from '../../configuration'
-import AlertPage from '../../pages/AlertPage'
 import AddVisaResidentWithPHNPage from '../../pages/enrollment/AddVisaResidentWithPHNPage'
+import AlertPage from '../../pages/AlertPage'
+import { OUTPUT_DATE_FORMAT } from '../../../../src/util/constants'
 import PersonDetails from '../../pages/enrollment/PersonDetailsPage'
+import { SITE_UNDER_TEST } from '../../configuration'
+import dayjs from 'dayjs'
 import { regularAccUser } from '../../roles/roles'
 
 const immigrationCodeOption = AddVisaResidentWithPHNPage.immigrationCodeSelect.find('option')
@@ -87,6 +86,9 @@ test('Check required fields validation for mailing address', async (t) => {
     .click(PersonDetails.submitButton)
     .wait(5000)
     // Given required fields aren't filled out
+    // Mailing Address 1 may alreay have value
+    .selectText(AddVisaResidentWithPHNPage.mailingAddress1Input)
+    .pressKey('delete')
     .typeText(AddVisaResidentWithPHNPage.mailingAddress2Input, 'Test 111 ST')
     // When I click the submit button
     .click(AddVisaResidentWithPHNPage.submitButton)
@@ -170,7 +172,7 @@ test('Check invalid input field character validation', async (t) => {
     .click(AddVisaResidentWithPHNPage.provinceSelect)
     .click(provinceOption.withText('British Columbia'))
     .typeText(AddVisaResidentWithPHNPage.postalCodeInput, '[][][]')
-    .typeText(AddVisaResidentWithPHNPage.mailingAddress1Input, 'Test 111 +_)(*&')
+    .typeText(AddVisaResidentWithPHNPage.mailingAddress1Input, 'Test 111 +_)(*&', { replace: true })
     .typeText(AddVisaResidentWithPHNPage.mailingAddress2Input, 'Test 111 ST @@@@@')
     .typeText(AddVisaResidentWithPHNPage.mailingAddress3Input, '!@#$%^*(9')
     .typeText(AddVisaResidentWithPHNPage.mailingCityInput, 'VICTORIA<>')


### PR DESCRIPTION
The changes made to the testcases is due to the existing testcase failures as the 'Mailing Address 1' field comes pre-populated from test data, as testcafe appends the text with whatever the textbox has, the invalid testcase changes to max length one due to the pre-populated entry. Hence to prevent it we are now clearing the textbox input before adding any text to it. 