### PR TITLE
9294-fix-logs-being-archived-with-erroneous-file-name

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -24,7 +24,7 @@
                 class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- http://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy -->
             <!-- rollover daily and when the file reaches 10 MegaBytes -->
-            <fileNamePattern>${LOGS}/archived/ums-%d{yyyy-MM-dd}.%i.log
+            <fileNamePattern>${LOGS}/archived/hnweb-api-%d{yyyy-MM-dd}.%i.log
             </fileNamePattern>
             <!-- keep 30 days of history -->
             <maxHistory>30</maxHistory>


### PR DESCRIPTION
corrected archived log file name to use app name